### PR TITLE
nextgamekey pauses game, removed list clearing when stopping the shuffler

### DIFF
--- a/GameShuffler/Form1.cs
+++ b/GameShuffler/Form1.cs
@@ -115,7 +115,7 @@ namespace GameShuffler
         private void StopButton_Clicked(object sender, EventArgs e)
         {
             refreshButton.Enabled = true;
-            runningProcessesSelectionList.Items.Clear();
+            // runningProcessesSelectionList.Items.Clear();
             runningProcessesSelectionList.Enabled = true;
             startButton.Enabled = true;
             minTimeTextBox.Enabled = true;
@@ -255,6 +255,10 @@ namespace GameShuffler
 
                 if (id == NextGameKeyId && gamesToShuffle.Any()) 
                 {
+                    if (currentGame != null)
+                    {
+                        SuspendProcess(currentGame);
+                    }
                     StartNewGame();
                 }
             }


### PR DESCRIPTION
next game key now pauses the game before switching.

Also commented out the list clear when stopping the shuffler for easy re shuffling

I made these changes due to my personal annoyances using the program. This is the current version I use that I prefer.